### PR TITLE
feat(core): HTTP 요청/응답 로깅 기능 초기 구현

### DIFF
--- a/d-logger-core/src/main/kotlin/me/dhlee/context/TraceIdProvider.kt
+++ b/d-logger-core/src/main/kotlin/me/dhlee/context/TraceIdProvider.kt
@@ -1,0 +1,19 @@
+package me.dhlee.context
+
+import org.slf4j.MDC
+import java.util.*
+
+object TraceIdProvider {
+
+    private const val TRACE_ID_KEY = "d-logger-trace-id"
+
+    fun getOrCreate(): String {
+        return get() ?: UUID.randomUUID().toString().also(TraceIdProvider::set)
+    }
+
+    fun get(): String? = MDC.get(TRACE_ID_KEY)
+
+    fun set(traceId: String) = MDC.put(TRACE_ID_KEY, traceId)
+
+    fun clear() = MDC.remove(TRACE_ID_KEY)
+}

--- a/d-logger-core/src/main/kotlin/me/dhlee/format/DefaultHttpLogFormatter.kt
+++ b/d-logger-core/src/main/kotlin/me/dhlee/format/DefaultHttpLogFormatter.kt
@@ -1,0 +1,55 @@
+package me.dhlee.format
+
+import me.dhlee.mask.HeaderMasker
+import me.dhlee.model.HttpRequestLog
+import me.dhlee.model.HttpResponseLog
+import me.dhlee.properties.HttpLoggingProperties
+import me.dhlee.resolver.BodyMaskerResolver
+
+class DefaultHttpLogFormatter(
+    private val properties: HttpLoggingProperties
+) : HttpLogFormatter {
+
+    private val headerMasker: HeaderMasker = HeaderMasker(properties)
+    private val bodyMaskerResolver = BodyMaskerResolver(properties)
+
+    override fun formatRequest(request: HttpRequestLog): String {
+        val maskedHeader = headerMasker.mask(request.headers)
+
+        val bodyMasker = bodyMaskerResolver.resolve(request.contentType)
+        val maskedBody = if (properties.includeBody) {
+            bodyMasker.mask(request.body)
+        } else {
+            "[Body omitted]"
+        }
+
+        return """
+            |[REQUEST - ${request.traceId}]
+            |${request.method} ${request.path}
+            |${maskedHeader.entries.joinToString("\n") { "${it.key}: ${it.value}" }}
+            |
+            |$maskedBody
+            
+        """.trimMargin()
+    }
+
+    override fun formatResponse(response: HttpResponseLog): String {
+        val maskedHeader = headerMasker.mask(response.headers)
+
+        val bodyMasker = bodyMaskerResolver.resolve(response.contentType)
+        val maskedBody = if (properties.includeBody) {
+            bodyMasker.mask(response.body)
+        } else {
+            "[Body omitted]"
+        }
+
+        return """
+            |[RESPONSE - ${response.traceId}]
+            |${response.status} ${response.method} ${response.path}
+            |${maskedHeader.entries.joinToString("\n") { "${it.key}: ${it.value}" }}
+            |
+            |$maskedBody
+            
+        """.trimMargin()
+    }
+}

--- a/d-logger-core/src/main/kotlin/me/dhlee/format/HttpLogFormatter.kt
+++ b/d-logger-core/src/main/kotlin/me/dhlee/format/HttpLogFormatter.kt
@@ -1,0 +1,10 @@
+package me.dhlee.format
+
+import me.dhlee.model.HttpRequestLog
+import me.dhlee.model.HttpResponseLog
+
+interface HttpLogFormatter {
+    fun formatRequest(request: HttpRequestLog): String
+
+    fun formatResponse(response: HttpResponseLog): String
+}

--- a/d-logger-core/src/main/kotlin/me/dhlee/logger/HttpLogger.kt
+++ b/d-logger-core/src/main/kotlin/me/dhlee/logger/HttpLogger.kt
@@ -1,0 +1,21 @@
+package me.dhlee.logger
+
+import me.dhlee.format.HttpLogFormatter
+import me.dhlee.model.HttpRequestLog
+import me.dhlee.model.HttpResponseLog
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class HttpLogger(
+    private val formatter: HttpLogFormatter
+){
+    private val log: Logger = LoggerFactory.getLogger(HttpLogger::class.java)
+
+    fun logRequest(request: HttpRequestLog) {
+        log.info(formatter.formatRequest(request))
+    }
+
+    fun logResponse(response: HttpResponseLog) {
+        log.info(formatter.formatResponse(response))
+    }
+}

--- a/d-logger-core/src/main/kotlin/me/dhlee/mask/BodyMasker.kt
+++ b/d-logger-core/src/main/kotlin/me/dhlee/mask/BodyMasker.kt
@@ -1,0 +1,6 @@
+package me.dhlee.mask
+
+interface BodyMasker {
+
+    fun mask(body: String?): String
+}

--- a/d-logger-core/src/main/kotlin/me/dhlee/mask/FormUrlEncodedBodyMasker.kt
+++ b/d-logger-core/src/main/kotlin/me/dhlee/mask/FormUrlEncodedBodyMasker.kt
@@ -1,0 +1,30 @@
+package me.dhlee.mask
+
+import me.dhlee.properties.HttpLoggingProperties
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+class FormUrlEncodedBodyMasker(
+    props: HttpLoggingProperties,
+) : BodyMasker {
+    private val keysToMask: Set<String> = props.maskBody.map { it.lowercase() }.toSet()
+
+    override fun mask(body: String?): String {
+        if (body.isNullOrBlank()) return ""
+
+        return body.split("&").joinToString("&") { pair ->
+            val (rawKey, rawValue) = pair.split("=", limit = 2).let {
+                when (it.size) {
+                    2 -> it[0] to it[1]
+                    1 -> it[0] to ""
+                    else -> "" to ""
+                }
+            }
+
+            val key = URLDecoder.decode(rawKey, StandardCharsets.UTF_8)
+            val value = URLDecoder.decode(rawValue, StandardCharsets.UTF_8)
+
+            if (key.lowercase() in keysToMask) "$key=****" else "$key=$value"
+        }
+    }
+}

--- a/d-logger-core/src/main/kotlin/me/dhlee/mask/HeaderMasker.kt
+++ b/d-logger-core/src/main/kotlin/me/dhlee/mask/HeaderMasker.kt
@@ -1,0 +1,16 @@
+package me.dhlee.mask
+
+import me.dhlee.properties.HttpLoggingProperties
+
+class HeaderMasker(
+    props: HttpLoggingProperties,
+) {
+    private val keysToMask: Set<String> = props.maskHeaders.map { it.lowercase() }.toSet()
+
+    fun mask(headers: Map<String, String>): Map<String, String> {
+        return headers.map { (key, value) ->
+            val masked = key.lowercase() in keysToMask
+            if (masked) key to "****" else key to value
+        }.toMap()
+    }
+}

--- a/d-logger-core/src/main/kotlin/me/dhlee/mask/JsonBodyMasker.kt
+++ b/d-logger-core/src/main/kotlin/me/dhlee/mask/JsonBodyMasker.kt
@@ -1,0 +1,67 @@
+package me.dhlee.mask
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import me.dhlee.properties.HttpLoggingProperties
+
+class JsonBodyMasker(
+    props: HttpLoggingProperties,
+) : BodyMasker {
+    private val mapper: ObjectMapper = ObjectMapper().apply { enable(SerializationFeature.INDENT_OUTPUT) }
+    private val keysToMask: Set<String> = props.maskBody.map { it.lowercase() }.toSet()
+
+    // TODO: maxBodyLength를 적용했을 때, body가 잘려서 json이 아닐 경우에 대한 처리
+    //       이 경우, regEx로 body를 mask하는 방법도 고려해볼 수 있음 (우선, truncated라고만 표시)
+    // TODO: LEAVES 마스킹 전략에 대한 기능 추가
+    override fun mask(body: String?): String {
+        return when {
+            body.isNullOrBlank() -> ""
+            isJson(body) -> maskJsonBody(body)
+            else -> body
+        }
+    }
+
+    private fun isJson(body: String): Boolean {
+        return try {
+            mapper.readTree(body)
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    private fun maskJsonBody(body: String): String {
+        val node = mapper.readTree(body)
+        val maskedNode = maskNode(node)
+        return mapper.writeValueAsString(maskedNode)
+    }
+
+    private fun maskNode(node: JsonNode): JsonNode {
+        return when {
+            node.isObject -> {
+                val obj = node.deepCopy<ObjectNode>()
+                for ((key, value) in obj.fields()) {
+                    if (key.lowercase() in keysToMask && value.isTextual) {
+                        obj.put(key, "****")
+                    } else {
+                        obj.set(key, maskNode(value))
+                    }
+                }
+                obj
+            }
+
+            node.isArray -> {
+                val arr = node.deepCopy<ArrayNode>()
+                for (i in 0 until arr.size()) {
+                    arr.set(i, maskNode(arr[i]))
+                }
+                arr
+            }
+
+            else -> node
+        }
+    }
+}

--- a/d-logger-core/src/main/kotlin/me/dhlee/mask/NoOpBodyMasker.kt
+++ b/d-logger-core/src/main/kotlin/me/dhlee/mask/NoOpBodyMasker.kt
@@ -1,0 +1,5 @@
+package me.dhlee.mask
+
+class NoOpBodyMasker: BodyMasker {
+    override fun mask(body: String?): String = body.orEmpty()
+}

--- a/d-logger-core/src/main/kotlin/me/dhlee/model/HttpRequestLog.kt
+++ b/d-logger-core/src/main/kotlin/me/dhlee/model/HttpRequestLog.kt
@@ -1,0 +1,10 @@
+package me.dhlee.model
+
+data class HttpRequestLog(
+    val traceId: String,
+    val method: String,
+    val path: String,
+    val headers: Map<String, String>,
+    val body: String,
+    val contentType: String?,
+)

--- a/d-logger-core/src/main/kotlin/me/dhlee/model/HttpResponseLog.kt
+++ b/d-logger-core/src/main/kotlin/me/dhlee/model/HttpResponseLog.kt
@@ -1,0 +1,11 @@
+package me.dhlee.model
+
+data class HttpResponseLog(
+    val traceId: String,
+    val status: Int,
+    val method: String,
+    val path: String,
+    val headers: Map<String, String>,
+    val body: String,
+    val contentType: String?,
+)

--- a/d-logger-core/src/main/kotlin/me/dhlee/properties/HttpLoggingProperties.kt
+++ b/d-logger-core/src/main/kotlin/me/dhlee/properties/HttpLoggingProperties.kt
@@ -1,0 +1,7 @@
+package me.dhlee.properties
+
+data class HttpLoggingProperties(
+    val includeBody: Boolean = true,
+    val maskHeaders: Set<String> = setOf(),
+    val maskBody: Set<String> = setOf(),
+)

--- a/d-logger-core/src/main/kotlin/me/dhlee/resolver/BodyMaskerResolver.kt
+++ b/d-logger-core/src/main/kotlin/me/dhlee/resolver/BodyMaskerResolver.kt
@@ -1,0 +1,24 @@
+package me.dhlee.resolver
+
+import me.dhlee.mask.BodyMasker
+import me.dhlee.mask.FormUrlEncodedBodyMasker
+import me.dhlee.mask.JsonBodyMasker
+import me.dhlee.mask.NoOpBodyMasker
+import me.dhlee.properties.HttpLoggingProperties
+
+class BodyMaskerResolver(
+    properties: HttpLoggingProperties
+) {
+    private val noOpMasker = NoOpBodyMasker()
+    private val jsonMasker = JsonBodyMasker(properties)
+    private val formMasker = FormUrlEncodedBodyMasker(properties)
+
+    fun resolve(contentType: String?): BodyMasker {
+        return when {
+            contentType == null -> noOpMasker
+            contentType.contains("application/json") -> jsonMasker
+            contentType.contains("application/x-www-form-urlencoded") -> formMasker
+            else -> noOpMasker
+        }
+    }
+}

--- a/d-logger-core/src/test/kotlin/me/dhlee/context/TraceIdProviderTest.kt
+++ b/d-logger-core/src/test/kotlin/me/dhlee/context/TraceIdProviderTest.kt
@@ -1,0 +1,44 @@
+package me.dhlee.context
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.slf4j.MDC
+
+private const val TRACE_ID_KEY = "d-logger-trace-id"
+
+class TraceIdProviderTest {
+
+    @AfterEach
+    fun tearDown() {
+        MDC.clear()
+    }
+
+    @Test
+    fun `traceId가 저장되어 있으면 traceId를 반환한다`() {
+        val traceId = "test-trace-id"
+        TraceIdProvider.set(traceId)
+
+        val result = TraceIdProvider.getOrCreate()
+
+        assertEquals(traceId, result)
+    }
+
+    @Test
+    fun `traceId가 없으면 새로 생성해서 반환한다`() {
+        val result = TraceIdProvider.getOrCreate()
+
+        assertNotNull(result)
+        assertEquals(result, MDC.get(TRACE_ID_KEY))
+    }
+
+    @Test
+    fun `clear 하면 traceId가 제거된다`() {
+        TraceIdProvider.set("test-trace-id")
+        TraceIdProvider.clear()
+
+        val result = MDC.get(TRACE_ID_KEY)
+        assertEquals(null, result)
+    }
+}

--- a/d-logger-core/src/test/kotlin/me/dhlee/mask/FormUrlEncodedBodyMaskerTest.kt
+++ b/d-logger-core/src/test/kotlin/me/dhlee/mask/FormUrlEncodedBodyMaskerTest.kt
@@ -1,0 +1,66 @@
+package me.dhlee.mask
+
+import me.dhlee.properties.HttpLoggingProperties
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+
+class FormUrlEncodedBodyMaskerTest {
+
+    private val keyToMask = "email"
+
+    private val masker = FormUrlEncodedBodyMasker(
+        HttpLoggingProperties(maskBody = setOf(keyToMask))
+    )
+
+    @Test
+    fun `마스킹 대상 키의 값을 대소문자와 관계없이 마스킹할 수 있다`() {
+        val input = "name=userA=userB&${keyToMask.uppercase()}=testemail@email.com"
+        val expected = "name=userA=userB&${keyToMask.uppercase()}=****"
+
+        val masker = masker.mask(input)
+
+        assertEquals(expected, masker)
+    }
+
+    @Test
+    fun `URL 디코딩된 키 기준으로 마스킹할 수 있다`() {
+        val encodedKeyToMask = keyToMask.toByteArray(Charsets.US_ASCII).joinToString("") {
+            "%${String.format("%02X", it)}"
+        }
+        val input = "$encodedKeyToMask=test@test.com"
+        val expected = "$keyToMask=****"
+
+        val result = masker.mask(input)
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `마스킹 대상 키와 동일한 문자열을 가진 값은 마스킹되지 않는다`() {
+        val input = "username=$keyToMask"
+        val expected = "username=$keyToMask"
+
+        val result = masker.mask(input)
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `마스킹 대상 키의 값이 비어있는 경우에도 마스킹한 값을 반환한다`() {
+        val input = "$keyToMask="
+        val expected = "$keyToMask=****"
+
+        val result = masker.mask(input)
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `null 또는 빈 문자열인 경우 빈 문자열을 반환한다`() {
+        assertTrue(masker.mask("") == "")
+        assertTrue(masker.mask("  ") == "")
+        assertTrue(masker.mask(null) == "")
+    }
+}

--- a/d-logger-core/src/test/kotlin/me/dhlee/mask/HeaderMaskerTest.kt
+++ b/d-logger-core/src/test/kotlin/me/dhlee/mask/HeaderMaskerTest.kt
@@ -1,0 +1,49 @@
+package me.dhlee.mask
+
+import me.dhlee.properties.HttpLoggingProperties
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class HeaderMaskerTest {
+
+    private val keyToMask = "Authorization"
+    
+    private val masker = HeaderMasker(
+        HttpLoggingProperties(
+            maskHeaders = setOf(keyToMask),
+        )
+    )
+
+    @Test
+    fun `마스킹 대상 헤더의 값을 헤더의 대소문자와 관계없이 마스킹할 수 있다`() {
+        val key = keyToMask.uppercase()
+        val headers = mapOf(
+            key to "Bearer token123",
+        )
+        
+        val result = masker.mask(headers)
+        
+        assertEquals("****", result[key])
+    }
+    
+    @Test
+    fun `마스킹 대상이 없으면 원본 값을 반환한다`() {
+        val headers = mapOf(
+            "Content-Type" to "application/json"
+        )
+        
+        val result = masker.mask(headers)
+        
+        assertEquals("application/json", result["Content-Type"])
+    }
+    
+    @Test
+    fun `헤더가 비어있으면 빈 결과를 반환한다`() {
+        val headers = emptyMap<String, String>()
+        
+        val result = masker.mask(headers)
+        
+        assertTrue(result.isEmpty())
+    }
+}

--- a/d-logger-core/src/test/kotlin/me/dhlee/mask/JsonBodyMaskerTest.kt
+++ b/d-logger-core/src/test/kotlin/me/dhlee/mask/JsonBodyMaskerTest.kt
@@ -1,0 +1,86 @@
+package me.dhlee.mask
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import me.dhlee.properties.HttpLoggingProperties
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class JsonBodyMaskerTest {
+
+    private val keyToMask = "email"
+
+    private val masker = JsonBodyMasker(
+        HttpLoggingProperties(
+            maskBody = setOf(keyToMask),
+        )
+    )
+
+    private val objectMapper = ObjectMapper()
+
+    @Test
+    fun `단일 키를 마스킹할 수 있다`() {
+        val input = """{"$keyToMask": "test@test.com"}""".trimIndent()
+
+        val result = masker.mask(input)
+
+        val json = objectMapper.readTree(result)
+        assertTrue(json.get(keyToMask).asText() == "****")
+    }
+    
+    @Test
+    fun `중첩 객체안에 있는 키를 마스킹할 수 있다`() {
+        val input = """{"data": {"$keyToMask": "test@test.com"}}""".trimIndent()
+        
+        val result = masker.mask(input)
+
+        val json = objectMapper.readTree(result)
+        assertTrue(json["data"].get(keyToMask).asText() == "****")
+    }
+    
+    @Test
+    fun `배열 안에 있는 키를 마스킹할 수 있다`() {
+        val input = """{"list": [{"email": "testA@test.com"}, {"email": "testB@test.com"}]}""".trimIndent()
+
+        val result = masker.mask(input)
+
+        val json = objectMapper.readTree(result)
+        assertTrue(json["list"][0]["email"].asText() == "****")
+        assertTrue(json["list"][1]["email"].asText() == "****")
+    }
+
+    @Test
+    fun `마스킹 대상 키의 대소문자와 관계없이 마스킹할 수 있다`() {
+        val input = """{"${keyToMask.uppercase()}": "test@test.com"}""".trimIndent()
+
+        val result = masker.mask(input)
+
+        val json = objectMapper.readTree(result)
+        assertTrue(json.get(keyToMask.uppercase()).asText() == "****")
+    }
+
+    @Test
+    fun `마스킹 대상 키와 동일한 문자열을 가진 값은 마스킹되지 않는다`() {
+        val input = """{"name": "$keyToMask"}""".trimIndent()
+
+        val result = masker.mask(input)
+
+        val json = objectMapper.readTree(result)
+        assertTrue(json.get("name").asText() == keyToMask)
+    }
+
+    @Test
+    fun `비정상적인 JSON은 원본 값을 반환한다`() {
+        val input = """{"${keyToMask.uppercase()}": "test@test.com"]""".trimIndent()
+
+        val masked = masker.mask(input)
+
+        assertTrue(masked == input)
+    }
+    
+    @Test
+    fun `null 또는 빈 문자열인 경우 빈 문자열을 반환한다`() {
+        assertTrue(masker.mask("") == "")
+        assertTrue(masker.mask("  ") == "")
+        assertTrue(masker.mask(null) == "")
+    }
+}

--- a/d-logger-core/src/test/kotlin/me/dhlee/mask/NoOpBodyMaskerTest.kt
+++ b/d-logger-core/src/test/kotlin/me/dhlee/mask/NoOpBodyMaskerTest.kt
@@ -1,0 +1,17 @@
+package me.dhlee.mask
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import kotlin.test.Test
+
+class NoOpBodyMaskerTest {
+
+    @Test
+    fun `NoOpBodyMasker는 원본 값을 반환한다`() {
+        val masker = NoOpBodyMasker()
+        val body = "password is 1234"
+
+        val result = masker.mask(body)
+
+        assertEquals(body, result)
+    }
+}

--- a/d-logger-core/src/test/kotlin/me/dhlee/resolver/BodyMaskerResolverTest.kt
+++ b/d-logger-core/src/test/kotlin/me/dhlee/resolver/BodyMaskerResolverTest.kt
@@ -1,0 +1,52 @@
+package me.dhlee.resolver
+
+import me.dhlee.mask.FormUrlEncodedBodyMasker
+import me.dhlee.mask.JsonBodyMasker
+import me.dhlee.mask.NoOpBodyMasker
+import me.dhlee.properties.HttpLoggingProperties
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class BodyMaskerResolverTest {
+
+    private val properties = HttpLoggingProperties(
+        includeBody = true,
+        maskHeaders = emptySet(),
+        maskBody = setOf("password", "token")
+    )
+    private val resolver = BodyMaskerResolver(properties)
+
+    @Test
+    fun `Content-Type이 application-json인 경우 JsonBodyMasker를 반환한다`() {
+        val contentType = "application/json"
+
+        val masker = resolver.resolve(contentType)
+
+        assertTrue(masker is JsonBodyMasker)
+    }
+
+    @Test
+    fun `Content-Type이 application-x-www-form-urlencoded인 경우 FormUrlEncodedBodyMasker를 반환한다`() {
+        val contentType = "application/x-www-form-urlencoded"
+
+        val masker = resolver.resolve(contentType)
+
+        assertTrue(masker is FormUrlEncodedBodyMasker)
+    }
+
+    @Test
+    fun `Content-Type이 없으면 noOpMasker를 반환한다`() {
+        val masker = resolver.resolve(null)
+
+        assertTrue(masker is NoOpBodyMasker)
+    }
+
+    @Test
+    fun `지원되지 않은 Content-Type이면 noOpMasker를 반환한다`() {
+        val contentType = "text/plain"
+
+        val masker = resolver.resolve(contentType)
+
+        assertTrue(masker is NoOpBodyMasker)
+    }
+}


### PR DESCRIPTION
## 주요 변경사항

- `HttpLoggingProperties`: 로깅 설정 속성 정의
- `HttpRequestLog`, `HttpResponseLog`: 요청/응답 데이터 캡쳐 모델
- `BodyMasker` 인터페이스 및 구현체 3종 추가
  - NoOpBodyMasker
  - FormUrlEncodedBodyMasker
  - JsonBodyMasker
- `HeaderMasker`: 민감 헤더 마스킹 처리
- `BodyMaskerResolver`: Content-Type 기반 마스커 선택
- `DefaultHttpLogFormatter`: 로깅 포맷 구성
- MDC 기반 `traceId` 로깅 지원

## 비고

- Spring 의존성 없이 동작 가능하도록 core 모듈로 분리
- 마스킹 관련 기능은 확장 가능하게 설계
- 이후 Spring 모듈에서 Spring Filter + 적용 예정

close #1 