### PR TITLE
feat(spring): Spring 기반 HTTP 로깅 기능 연동 모듈 구현

### DIFF
--- a/d-logger-spring/src/main/kotlin/me/dhlee/common/HttpLoggingConstants.kt
+++ b/d-logger-spring/src/main/kotlin/me/dhlee/common/HttpLoggingConstants.kt
@@ -1,0 +1,7 @@
+package me.dhlee.common
+
+object HttpLoggingConstants {
+
+    const val DLOGGER_LOG_MARKER_KEY = "dlogger-log-marker"
+    const val DLOGGER_LOG_MARKER_VALUE = ""
+}

--- a/d-logger-spring/src/main/kotlin/me/dhlee/config/HttpLoggingAutoConfiguration.kt
+++ b/d-logger-spring/src/main/kotlin/me/dhlee/config/HttpLoggingAutoConfiguration.kt
@@ -1,0 +1,75 @@
+package me.dhlee.config
+
+import me.dhlee.filter.DefaultPathFilter
+import me.dhlee.filter.HttpLoggingFilter
+import me.dhlee.filter.HttpLoggingInterceptor
+import me.dhlee.filter.PathFilter
+import me.dhlee.format.DefaultHttpLogFormatter
+import me.dhlee.format.HttpLogFormatter
+import me.dhlee.logger.HttpLogger
+import me.dhlee.properties.SpringHttpLoggingProperties
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@EnableConfigurationProperties(SpringHttpLoggingProperties::class)
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@AutoConfiguration
+class HttpLoggingAutoConfiguration(
+    private val props: SpringHttpLoggingProperties
+) {
+    @Bean
+    @ConditionalOnMissingBean(HttpLogFormatter::class)
+    fun httpLogFormatter(props: SpringHttpLoggingProperties): HttpLogFormatter {
+        return DefaultHttpLogFormatter(props.toCoreProperties())
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(HttpLogger::class)
+    fun httpLogger(formatter: HttpLogFormatter): HttpLogger {
+        return HttpLogger(formatter)
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(PathFilter::class)
+    fun pathFilter(): PathFilter {
+        return DefaultPathFilter(
+            include = props.includePaths,
+            exclude = props.excludePaths
+        )
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(HttpLoggingFilter::class)
+    fun httpLoggingFilter(
+        httpLogger: HttpLogger,
+        pathFilter: PathFilter,
+    ): FilterRegistrationBean<HttpLoggingFilter> {
+        val filter = HttpLoggingFilter(props, httpLogger, pathFilter)
+        return FilterRegistrationBean(filter).apply { order = Ordered.HIGHEST_PRECEDENCE }
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(HttpLoggingInterceptor::class)
+    fun httpLoggingInterceptor(): HttpLoggingInterceptor {
+        return HttpLoggingInterceptor()
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    internal class InterceptorRegistrationConfiguration(
+        private val httpLoggingInterceptor: HttpLoggingInterceptor
+    ) : WebMvcConfigurer {
+        override fun addInterceptors(registry: InterceptorRegistry) {
+            registry.addInterceptor(httpLoggingInterceptor)
+                .addPathPatterns("/**")
+                .order(Ordered.HIGHEST_PRECEDENCE)
+        }
+    }
+}

--- a/d-logger-spring/src/main/kotlin/me/dhlee/filter/DefaultPathFilter.kt
+++ b/d-logger-spring/src/main/kotlin/me/dhlee/filter/DefaultPathFilter.kt
@@ -1,0 +1,19 @@
+package me.dhlee.filter
+
+import org.springframework.util.AntPathMatcher
+import org.springframework.util.PathMatcher
+
+class DefaultPathFilter (
+    private val include: Set<String>,
+    private val exclude: Set<String>,
+    private val matcher: PathMatcher = AntPathMatcher(),
+) : PathFilter {
+
+    override fun shouldLog(path: String): Boolean {
+        return when {
+            exclude.any { matcher.match(it, path) } -> false
+            include.none() -> true
+            else -> include.any { matcher.match(it, path) }
+        }
+    }
+}

--- a/d-logger-spring/src/main/kotlin/me/dhlee/filter/HttpLoggingFilter.kt
+++ b/d-logger-spring/src/main/kotlin/me/dhlee/filter/HttpLoggingFilter.kt
@@ -1,0 +1,103 @@
+package me.dhlee.filter
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import me.dhlee.common.HttpLoggingConstants
+import me.dhlee.context.TraceIdProvider
+import me.dhlee.logger.HttpLogger
+import me.dhlee.model.HttpRequestLog
+import me.dhlee.model.HttpResponseLog
+import me.dhlee.properties.SpringHttpLoggingProperties
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.util.ContentCachingRequestWrapper
+import org.springframework.web.util.ContentCachingResponseWrapper
+import java.net.URLDecoder
+
+class HttpLoggingFilter(
+    private val props: SpringHttpLoggingProperties,
+    private val httpLogger: HttpLogger,
+    private val pathFilter: PathFilter
+) : OncePerRequestFilter() {
+    override fun shouldNotFilterAsyncDispatch(): Boolean = false
+    override fun shouldNotFilterErrorDispatch(): Boolean = false
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val wrappedRequest = ContentCachingRequestWrapper(request)
+        val wrappedResponse = ContentCachingResponseWrapper(response)
+        try {
+            filterChain.doFilter(wrappedRequest, wrappedResponse)
+        } finally {
+            logIfNecessary(wrappedRequest, wrappedResponse)
+            wrappedResponse.copyBodyToResponse()
+            TraceIdProvider.clear()
+        }
+    }
+
+    private fun logIfNecessary(
+        request: ContentCachingRequestWrapper,
+        response: ContentCachingResponseWrapper
+    ) {
+        if (props.prod && request.getAttribute(HttpLoggingConstants.DLOGGER_LOG_MARKER_KEY) == null) {
+            return
+        }
+
+        val method = request.method
+        val path = extractPath(request)
+        if (!pathFilter.shouldLog(path)) {
+            return
+        }
+
+        val traceId = TraceIdProvider.getOrCreate()
+
+        val requestLog = HttpRequestLog(
+            traceId = traceId,
+            method = method,
+            path = path,
+            headers = extractHeaders(request),
+            body = getRequestBody(request),
+            contentType = request.contentType,
+        )
+
+        val responseLog = HttpResponseLog(
+            traceId = traceId,
+            status = response.status,
+            method = method,
+            path = path,
+            headers = extractHeaders(response),
+            body = getResponseBody(response),
+            contentType = response.contentType,
+        )
+
+        httpLogger.logRequest(requestLog)
+        httpLogger.logResponse(responseLog)
+    }
+
+    private fun extractPath(request: ContentCachingRequestWrapper) =
+        request.requestURI + request.queryString?.let { URLDecoder.decode(it, Charsets.UTF_8) }.orEmpty()
+
+    private fun extractHeaders(request: ContentCachingRequestWrapper): Map<String, String> {
+        return request.headerNames.toList().associateWith { name ->
+            request.getHeader(name)
+        }
+    }
+
+    private fun extractHeaders(response: ContentCachingResponseWrapper): Map<String, String> {
+        return response.headerNames.toList().associateWith { name ->
+            response.getHeader(name) ?: ""
+        }
+    }
+
+    private fun getRequestBody(request: ContentCachingRequestWrapper): String {
+        return toString(request.contentAsByteArray)
+    }
+
+    private fun getResponseBody(response: ContentCachingResponseWrapper): String {
+        return toString(response.contentAsByteArray)
+    }
+
+    private fun toString(bytes: ByteArray): String = String(bytes, Charsets.UTF_8)
+}

--- a/d-logger-spring/src/main/kotlin/me/dhlee/filter/HttpLoggingInterceptor.kt
+++ b/d-logger-spring/src/main/kotlin/me/dhlee/filter/HttpLoggingInterceptor.kt
@@ -1,0 +1,20 @@
+package me.dhlee.filter
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import me.dhlee.common.HttpLoggingConstants
+import org.springframework.web.servlet.HandlerInterceptor
+
+class HttpLoggingInterceptor : HandlerInterceptor {
+
+    override fun afterCompletion(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+        ex: Exception?
+    ) {
+        if (ex != null) {
+            request.setAttribute(HttpLoggingConstants.DLOGGER_LOG_MARKER_KEY, "");
+        }
+    }
+}

--- a/d-logger-spring/src/main/kotlin/me/dhlee/filter/PathFilter.kt
+++ b/d-logger-spring/src/main/kotlin/me/dhlee/filter/PathFilter.kt
@@ -1,0 +1,6 @@
+package me.dhlee.filter
+
+interface PathFilter {
+
+    fun shouldLog(path: String): Boolean
+}

--- a/d-logger-spring/src/main/kotlin/me/dhlee/properties/SpringHttpLoggingProperties.kt
+++ b/d-logger-spring/src/main/kotlin/me/dhlee/properties/SpringHttpLoggingProperties.kt
@@ -1,0 +1,21 @@
+package me.dhlee.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "http-logging")
+data class SpringHttpLoggingProperties(
+    var prod: Boolean = true,
+    var includeBody: Boolean = true,
+    var includePaths: Set<String> = emptySet(),
+    var excludePaths: Set<String> = emptySet(),
+    var maskHeaders: Set<String> = emptySet(),
+    var maskBody: Set<String> = emptySet(),
+) {
+    fun toCoreProperties(): HttpLoggingProperties {
+        return HttpLoggingProperties(
+            includeBody = includeBody,
+            maskHeaders = maskHeaders,
+            maskBody = maskBody
+        )
+    }
+}

--- a/d-logger-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/d-logger-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+me.dhlee.config.HttpLoggingAutoConfiguration

--- a/d-logger-spring/src/test/kotlin/me/dhlee/config/CustomLoggerTest.kt
+++ b/d-logger-spring/src/test/kotlin/me/dhlee/config/CustomLoggerTest.kt
@@ -1,0 +1,22 @@
+package me.dhlee.config
+
+import me.dhlee.logger.HttpLogger
+import org.mockito.Mockito
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@ImportAutoConfiguration(HttpLoggingAutoConfiguration::class)
+@SpringBootTest(classes = [CustomLoggerTest::class, TestConfig::class])
+class CustomLoggerTest {
+
+    @Autowired
+    lateinit var httpLogger: HttpLogger
+
+    @Test
+    fun `사용자 정의 HttpLogger 빈이 우선 적용된다`() {
+        assertTrue(Mockito.mockingDetails(httpLogger).isMock)
+    }
+}

--- a/d-logger-spring/src/test/kotlin/me/dhlee/config/HttpLoggingAutoConfigurationTest.kt
+++ b/d-logger-spring/src/test/kotlin/me/dhlee/config/HttpLoggingAutoConfigurationTest.kt
@@ -1,0 +1,36 @@
+package me.dhlee.config
+
+import me.dhlee.filter.PathFilter
+import me.dhlee.logger.HttpLogger
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.web.servlet.HandlerInterceptor
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+@ImportAutoConfiguration(HttpLoggingAutoConfiguration::class)
+@SpringBootTest(classes = [HttpLoggingAutoConfigurationTest::class])
+class HttpLoggingAutoConfigurationTest {
+
+    @Autowired
+    lateinit var httpLogger: HttpLogger
+
+    @Autowired
+    lateinit var pathFilter: PathFilter
+
+    @Autowired
+    lateinit var httpLoggingFilter: FilterRegistrationBean<*>
+
+    @Autowired
+    lateinit var interceptor: HandlerInterceptor
+
+    @Test
+    fun `auto configuration이 bean들을 정상 등록한다`() {
+        assertNotNull(httpLogger)
+        assertNotNull(pathFilter)
+        assertNotNull(httpLoggingFilter)
+        assertNotNull(interceptor)
+    }
+}

--- a/d-logger-spring/src/test/kotlin/me/dhlee/config/PropertiesBindingTest.kt
+++ b/d-logger-spring/src/test/kotlin/me/dhlee/config/PropertiesBindingTest.kt
@@ -1,0 +1,36 @@
+package me.dhlee.config
+
+import me.dhlee.filter.PathFilter
+import me.dhlee.properties.SpringHttpLoggingProperties
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@ImportAutoConfiguration(HttpLoggingAutoConfiguration::class)
+@SpringBootTest(classes = [PropertiesBindingTest::class])
+class PropertiesBindingTest {
+
+    @Autowired
+    lateinit var props: SpringHttpLoggingProperties
+
+    @Autowired
+    lateinit var pathFilter: PathFilter
+
+    @Test
+    fun `application yml 설정이 SpringHttpLoggingProperties에 바인딩된다`() {
+        assertEquals(setOf("/api/**"), props.includePaths)
+        assertEquals(setOf("/health"), props.excludePaths)
+        assertEquals(setOf("Authorization"), props.maskHeaders)
+        assertEquals(setOf("password"), props.maskBody)
+    }
+
+    @Test
+    fun `PathFilter에 설정이 실제로 반영된다`() {
+        assertTrue(pathFilter.shouldLog("/api/user"))
+        assertFalse(pathFilter.shouldLog("/health"))
+    }
+}

--- a/d-logger-spring/src/test/kotlin/me/dhlee/config/TestConfig.kt
+++ b/d-logger-spring/src/test/kotlin/me/dhlee/config/TestConfig.kt
@@ -1,0 +1,14 @@
+package me.dhlee.config
+
+import me.dhlee.logger.HttpLogger
+import org.mockito.Mockito.mock
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+
+@TestConfiguration
+class TestConfig {
+    @Bean
+    fun customHttpLogger(): HttpLogger {
+        return mock(HttpLogger::class.java)
+    }
+}

--- a/d-logger-spring/src/test/kotlin/me/dhlee/filter/DefaultPathFilterTest.kt
+++ b/d-logger-spring/src/test/kotlin/me/dhlee/filter/DefaultPathFilterTest.kt
@@ -1,0 +1,69 @@
+package me.dhlee.filter
+
+import org.springframework.util.AntPathMatcher
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultPathFilterTest {
+
+    private val matcher = AntPathMatcher()
+
+    @Test
+    fun `exclude 경로에 매치되면 false를 반한다`() {
+        val excludePath = "/api/test"
+
+        val filter = DefaultPathFilter(
+            include = setOf("/api/**"),
+            exclude = setOf(excludePath),
+            matcher = matcher,
+        )
+
+        val result = filter.shouldLog(excludePath)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `include 경로에 매치되면 true를 반환한다`() {
+        val includePath = "/api/test"
+
+        val filter = DefaultPathFilter(
+            include = setOf("/api/**"),
+            exclude = emptySet(),
+            matcher = matcher,
+        )
+
+        val result = filter.shouldLog(includePath)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `exclude, include 경로에 모두 매치되면 exclude가 우선 적용되어 false를 반환한다`() {
+        val path = "/api/test"
+
+        val filter = DefaultPathFilter(
+            include = setOf(path),
+            exclude = setOf(path),
+            matcher = matcher,
+        )
+
+        val result = filter.shouldLog(path)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `exclude, include 모두 비어있으면 true를 반환한다`() {
+        val filter = DefaultPathFilter(
+            include = emptySet(),
+            exclude = emptySet(),
+            matcher = matcher,
+        )
+
+        val result = filter.shouldLog("/api/test")
+
+        assertTrue(result)
+    }
+}

--- a/d-logger-spring/src/test/kotlin/me/dhlee/filter/HttpLoggingInterceptorTest.kt
+++ b/d-logger-spring/src/test/kotlin/me/dhlee/filter/HttpLoggingInterceptorTest.kt
@@ -1,0 +1,36 @@
+package me.dhlee.filter
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import me.dhlee.common.HttpLoggingConstants.DLOGGER_LOG_MARKER_KEY
+import me.dhlee.common.HttpLoggingConstants.DLOGGER_LOG_MARKER_VALUE
+import org.mockito.Mockito.*
+import kotlin.test.Test
+
+class HttpLoggingInterceptorTest {
+
+    private val interceptor = HttpLoggingInterceptor()
+
+    @Test
+    fun `예외가 발생하면 로그 마커를 설정한다`() {
+        val request = mock<HttpServletRequest>()
+        val response = mock<HttpServletResponse>()
+        val handler = Any()
+        val exception = Exception("Test Exception")
+
+        interceptor.afterCompletion(request, response, handler, exception)
+
+        verify(request).setAttribute(DLOGGER_LOG_MARKER_KEY, DLOGGER_LOG_MARKER_VALUE)
+    }
+
+    @Test
+    fun `예외가 발생하지 않으면 로그 마커를 설정하지 않는다`() {
+        val request = mock<HttpServletRequest>()
+        val response = mock<HttpServletResponse>()
+        val handler = Any()
+
+        interceptor.afterCompletion(request, response, handler, null)
+
+        verify(request, never()).setAttribute(any(), any())
+    }
+}

--- a/d-logger-spring/src/test/kotlin/me/dhlee/properties/SpringHttpLoggingPropertiesTest.kt
+++ b/d-logger-spring/src/test/kotlin/me/dhlee/properties/SpringHttpLoggingPropertiesTest.kt
@@ -1,0 +1,28 @@
+package me.dhlee.properties
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class SpringHttpLoggingPropertiesTest {
+
+    @Test
+    fun `HttpLoggingProperties 객체로 변환할 수 있다`() {
+        val includeBody = true
+        val maskHeaders = setOf("Authorization")
+        val maskBody = setOf("password")
+
+        val properties = SpringHttpLoggingProperties(
+            includeBody = includeBody,
+            maskHeaders = maskHeaders,
+            maskBody = maskBody
+        )
+
+        val result = properties.toCoreProperties()
+
+        assertNotNull(result)
+        assertEquals(includeBody, result.includeBody)
+        assertEquals(maskHeaders, result.maskHeaders)
+        assertEquals(maskBody, result.maskBody)
+    }
+}

--- a/d-logger-spring/src/test/resources/application.yml
+++ b/d-logger-spring/src/test/resources/application.yml
@@ -1,0 +1,9 @@
+http-logging:
+  include-paths:
+    - /api/**
+  exclude-paths:
+    - /health
+  mask-headers:
+    - Authorization
+  mask-body:
+    - password


### PR DESCRIPTION
## 주요 변경사항

- `SpringHttpLoggingProperties`: Spring 설정 기반 로깅 설정 클래스 추가
- `PathFilter` 인터페이스 및 `AntMatcher`로 작동하는 기본 구현체 추가
  - URL 경로에 따라 로깅 여부를 분기 가능
- `HttpLoggingInterceptor`: 예외 발생 시 request attribute를 설정하여 이후 필터에서 로깅 여부 판단 가능
- `HttpLoggingFilter`: prod 환경인 경우 예외가 발생한 요청에 한해 로깅 수행
- `HttpLoggingAutoConfiguration`: Spring 환경에서 필요한 Bean 자동 구성

## 비고

- prod 환경에서는 예외가 발생한 경우에만 로깅
- core 모듈에 정의된 마스커 및 로깅 구조와 연동

closes #3 